### PR TITLE
Fix global update on user progress

### DIFF
--- a/actions/user-progress.ts
+++ b/actions/user-progress.ts
@@ -31,11 +31,13 @@ export const upsertUserProgress = async (courseId: number) => {
   const existingUserProgress = await getUserProgress();
 
   if (existingUserProgress) {
-    await db.update(userProgress).set({
-      activeCourseId: courseId,
-      userName: user.firstName || "User",
-      userImageSrc: user.imageUrl || "/mascot.svg",
-    });
+    await db.update(userProgress)
+      .set({
+        activeCourseId: courseId,
+        userName: user.firstName || "User",
+        userImageSrc: user.imageUrl || "/mascot.svg",
+      })
+      .where(eq(userProgress.userId, userId));
 
     revalidatePath("/courses");
     revalidatePath("/learn");


### PR DESCRIPTION
## Summary
- fix update query when user progress exists

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68424273a7e8832f89764364fdd039da